### PR TITLE
Add momentum distribution loading for ^3He nucleus

### DIFF
--- a/pluto/quasifree/include/momentum_data_loader.h
+++ b/pluto/quasifree/include/momentum_data_loader.h
@@ -1,18 +1,20 @@
 /**
  * @file momentum_data_loader.h
  * @author AK <alex.nuclearboy@gmail.com>
- * @brief Declaration of MomentumDataLoader class for reading nucleon momentum 
+ * @brief Declaration of MomentumDataLoader class for loading momentum 
  *        distribution data.
  *
- * This class provides functionality to read data from a specified file 
- * containing nucleon momentum and probability values, and to construct 
- * a TGraph object from this data. The expected file format consists of lines 
- * with two numerical values per line, representing momentum and its 
- * corresponding probability.
- * 
+ * This class is designed to read and process data from files that contain 
+ * momentum and probability values, constructing a TGraph object from this data. 
+ * It is essential for simulations requiring momentum distributions, such as 
+ * quasi-elastic proton-deuteron scattering and the formation and decay of the
+ * bound ^3He-eta state. The expected file format is a text file where each
+ * line contains a pair of numerical values: the first representing momentum and
+ * the second its corresponding probability.
+ *
  * @version 2.0
- * @date 2024-02-21
- *  
+ * @date 2024-02-23
+ *
  * @note Distributed under the GNU General Public License version 3.0 (GPLv3).
  */
 
@@ -24,43 +26,92 @@
 
 /**
  * @class MomentumDataLoader
- * @brief Manages reading of nucleon momentum distribution data from files.
+ * @brief Manages the loading of momentum distribution data from files.
  *
- * This class encapsulates the process of opening a specified file, reading nucleon
- * momentum and probability values, and creating a TGraph object that represents
- * this data. It is designed to work with specific model data files, namely 'paris'
- * and 'cdbonn'.
+ * The MomentumDataLoader class encapsulates the process of opening specified 
+ * files, reading momentum and probability values, and generating a TGraph
+ * representation of this data.
  */
 class MomentumDataLoader {
 public:
     /**
-     * Constructor that initializes a MomentumDataLoader object with a file path.
+     * Constructs a MomentumDataLoader with a specified file path.
+     *
      * @param file_path Path to the file containing momentum distribution data.
      */
     explicit MomentumDataLoader(const std::string& file_path);
 
     /**
-     * Loads the nucleon momentum distribution data for a specified model.
+     * Loads the nucleon momentum distribution data for a specified potential model.
+     *
+     * Maps the model names to the corresponding data files and constructs
+     * a TGraph object representing the momentum distribution. 
+     * Currently supports 'paris' and 'cdbonn' models.
+     *
+     * @param model_name Name of the potential model for which to load momentum 
+     *                   distribution data.
+     * @return Pointer to a TGraph object containing momentum distribution data, 
+     *         or NULL if an error occurs.
      * 
-     * Maps model names to corresponding files and reads data to construct
-     * a TGraph object. Currently supports 'paris' and 'cdbonn' models.
-     * 
-     * @param model_name Name of the model whose momentum distribution is loaded.
-     * @return Pointer to a TGraph object with momentum distribution data, 
-     *         or NULL on error.
-     * 
-     * @note Momentum distribution files should be in the 
+     * @note Data files are expected to be located in the
      *       "../momentum_distributions/" directory.
      */
-    static TGraph* loadMomentumDistribution(const std::string& model_name);
+    static TGraph* loadDeuteronNMD(const std::string& model_name);
+
+    /**
+     * Loads momentum distribution for a proton or an N*(1535) resonance 
+     * within the ^3He nucleus.
+     *
+     * This method provides access to the momentum distribution data crucial for 
+     * simulations of the eta-mesic ^3He nucleus.
+     * It supports loading data for two specific scenarios:
+     * - The momentum distribution of a proton within the ^3He nucleus.
+     * - The theoretically calculated momentum distribution of the N*(1535) 
+     *   resonance within the ^3He nucleus, where the ^3He is considered 
+     *   as a bound resonance-deuteron system, for specific binding energies 
+     *   of 0.33, 0.53, and 0.74 MeV.
+     *
+     * @param particle_type Specifies the type of particle ("proton" or "resonance") 
+     *                      for which the momentum distribution is to be loaded.
+     * @param energy Specifies the binding energy in the resonance-deuteron system 
+     *               within the ^3He nucleus, relevant for resonance distributions. 
+     *               The default value (5.5 MeV) is primarily set for proton 
+     *               momentum distribution.
+     * @return Pointer to a TGraph object containing the momentum distribution data, 
+     *         or NULL if an error occurs.
+     *
+     * @note Data files are expected to be located in the 
+     *       "../momentum_distributions/" directory.
+     */
+
+    /**
+     * Loads the momentum distribution for resonance or proton within the ^3He nucleus.
+     *
+     * This method facilitates the loading of momentum distribution data for specific
+     * particle types and energies, constructing a TGraph object with the data. It
+     * supports distributions for proton momentum and resonances at specific binding
+     * energies, enhancing the simulation's accuracy for studies involving the ^3He nucleus.
+     *
+     * @param particle_type Type of a particle (proton or resonance) for which 
+     *                      to load momentum distribution.
+     * @param energy Energy of the binding energy in the resonance-deuteron system
+     *               within the ^3He nucleus, in MeV. Defaults to 5.5 MeV for protons.
+     * @return Pointer to a TGraph object containing the momentum distribution data,
+     *         or NULL if an error occurs.
+     *
+     * @note Data files are expected to be located in the 
+     *       "../momentum_distributions/" directory.
+     */
+    static TGraph* loadHeliumNMD(
+        const std::string& particle_type, const Double_t energy = 5.5);
 
 private:
     std::string file_path;  ///< Path to the data file.
 
     /**
      * Reads data from the file and constructs a TGraph object.
-     * @return Pointer to a TGraph object with file data.
-     * @throws std::runtime_error if the file cannot be opened.
+     * @return Pointer to a TGraph object containing the data from the file.
+     * @throws std::runtime_error if the file cannot be opened or read.
      */
     TGraph* readData();
 };

--- a/pluto/quasifree/src/main.cpp
+++ b/pluto/quasifree/src/main.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
 
     // Model selection and data loading
     std::string model_name = argv[1];
-    TGraph* graph = MomentumDataLoader::loadMomentumDistribution(model_name);
+    TGraph* graph = MomentumDataLoader::loadDeuteronNMD(model_name);
     if (graph == NULL || graph->GetN() <= 0) {
         std::cerr << "Error: Failed to load momentum distribution data." 
                   << std::endl;

--- a/pluto/quasifree/src/momentum_data_loader.cpp
+++ b/pluto/quasifree/src/momentum_data_loader.cpp
@@ -3,11 +3,22 @@
  * @author AK <alex.nuclearboy@gmail.com>
  * @brief Implementation of MomentumDataLoader class methods.
  *
- * Defines methods for opening a specified file, reading nucleon momentum and
- * probability data, and constructing a TGraph object to represent this data.
- * 
+ * This class encapsulates the detailed procedures for accessing, reading, and 
+ * processing momentum and probability data from external files, translating 
+ * it into TGraph objects for use in nuclear physics simulations. It includes 
+ * methods tailored for specific nuclear configurations and models.
+ *
+ * Key functionalities include:
+ * - Opening and validating data files based on path and model specifications.
+ * - Parsing file contents to extract momentum and probability pairs.
+ * - Dynamically constructing TGraph objects representing nucleon momentum 
+ *   distributions for various potentials and configurations.
+ * - Supporting custom scenarios, including nucleon momentum distributions 
+ *   within a deuteron for Paris and CD-Bonn potentials, and proton and N*(1535) 
+ *   resonance distributions within ^3He for defined binding energies.
+ *
  * @version 2.0
- * @date 2024-02-21
+ * @date 2024-02-23
  * 
  * @note Distributed under the GNU General Public License version 3.0 (GPLv3).
  */
@@ -20,12 +31,14 @@
 #include <stdexcept>
 #include <map>
 #include "TROOT.h"
-#include "TGraph.h"
 #include "Rtypes.h"
+#include "TGraph.h"
 
+// Constructor: Initialises the data loader with a specified file path.
 MomentumDataLoader::MomentumDataLoader(const std::string& file_path) 
     : file_path(file_path) {}
 
+// Reads momentum and probability data from a file, constructing a TGraph.
 TGraph* MomentumDataLoader::readData()
 {
     std::ifstream file(this->file_path.c_str());
@@ -36,11 +49,11 @@ TGraph* MomentumDataLoader::readData()
     std::vector<Double_t> momentum;
     std::vector<Double_t> probability;
     std::string line;
-    
+
     while (std::getline(file, line)) {
         std::istringstream iss(line);
         Double_t m, p;
-        if (!(iss >> m >> p)) { break; }    // Handle error or malformed line
+        if (!(iss >> m >> p)) { break; }    // Skips malformed lines
 
         momentum.push_back(m);
         probability.push_back(p);
@@ -50,7 +63,9 @@ TGraph* MomentumDataLoader::readData()
     return new TGraph(momentum.size(), &momentum[0], &probability[0]);
 }
 
-TGraph* MomentumDataLoader::loadMomentumDistribution(const std::string& model_name) 
+// Loads the momentum distribution of a nucleon within a deuteron 
+// based on the specified potential model.
+TGraph* MomentumDataLoader::loadDeuteronNMD(const std::string& model_name) 
 {
     // Map model names to their corresponding momentum distribution files
     std::map<std::string, std::string> model_to_file_map;
@@ -69,6 +84,41 @@ TGraph* MomentumDataLoader::loadMomentumDistribution(const std::string& model_na
     }
 
     MomentumDataLoader file_reader(model_to_file_map[model_name]);
+    return file_reader.readData();
+}
 
+// Loads the momentum distribution of a proton or N*(1535) resonance 
+// for a given energy.
+TGraph* MomentumDataLoader::loadHeliumNMD(
+    const std::string& particle_type, double energy) 
+{
+    // Maps particle types and energies to their corresponding file paths.
+    std::map<std::string, std::string> particle_file_map;
+    particle_file_map["proton"] = 
+        "../momentum_distributions/mom_distr_nucleon_3he_converted.txt";
+
+    std::map<double, std::string> energy_to_file_map;
+    energy_to_file_map.insert(std::make_pair(0.33, 
+        "../momentum_distributions/mom_distr_resonance_3he_e33_converted.txt"));
+    energy_to_file_map.insert(std::make_pair(0.53, 
+        "../momentum_distributions/mom_distr_resonance_3he_e53_converted.txt"));
+    energy_to_file_map.insert(std::make_pair(0.74, 
+        "../momentum_distributions/mom_distr_resonance_3he_e74_converted.txt"));
+
+    std::string distribution_file_path;
+
+    if (particle_type == "resonance" 
+        && energy_to_file_map.find(energy) != energy_to_file_map.end()) {
+        distribution_file_path = energy_to_file_map[energy];
+    } else if (particle_file_map.find(particle_type) != particle_file_map.end()) {
+        distribution_file_path = particle_file_map[particle_type];
+    } else {
+        std::cerr << "Error: No file associated with " << particle_type << " ."
+                  << "Available options are 'proton' and 'resonance' with "
+                  << "specific energies (0.33, 0.53 or 0.74 MeV)." << std::endl;
+        return NULL;
+    }
+
+    MomentumDataLoader file_reader(distribution_file_path);
     return file_reader.readData();
 }


### PR DESCRIPTION
- Rename `loadMomentumDistribution` to `loadDeuteronNMD` to more accurately reflect its functionality in loading deuteron nucleon momentum distributions.
- Implemented `loadHeliumNMD` method to facilitate the loading of momentum distribution data for "proton" and "resonance" particle types within the ^3He nucleus
- Improved documentation across both the header and implementation files